### PR TITLE
arreglo de fallo en la consola por que nos salia un error

### DIFF
--- a/client/src/components/CardAllInfoDoctor.jsx
+++ b/client/src/components/CardAllInfoDoctor.jsx
@@ -13,7 +13,7 @@ export const CardAllInfoDoctor = ({ doctor }) => {
             >
                 <li className="card-doctor">
                     <header>
-                        <a href={`/users/doctors/${doctor.userId}`}>
+                        
                             <img
                                 src={`${staticPath}/avatars/${doctor.userId}/${doctor.avatar}`}
                                 alt="Foto usuario"
@@ -23,7 +23,7 @@ export const CardAllInfoDoctor = ({ doctor }) => {
                                 }}
 
                             />
-                        </a>
+                    
                         <div>
                             <h3>{doctor.username}</h3>
                             <p>{doctor.Name}</p>


### PR DESCRIPTION
Nos  daba un error la consolo por que teniamos un enlace de navegacion en la imagen. luego al dar css le lo pusimos a la tarjeta entera, y no quitamos el de la imagen lo cual hace que la imagen tubiese dos navegaciones aunque eran al mismo sitio nos mostraba en pantalla el error.
